### PR TITLE
イベント概要にurlが含まれていたらlinkにする

### DIFF
--- a/src/components/Event/EventHeader/index.tsx
+++ b/src/components/Event/EventHeader/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Sectioning } from '../../uiParts/Sectioning';
 import styles from './index.module.scss';
 import { Heading } from '../../uiParts/Heading';
+import { StringWithUrl } from '../../uiParts/StringWithUrl';
 import { Event } from '../../../redux/modules/app/event';
 
 type Props = {
@@ -12,7 +13,9 @@ export const EventHeader: React.VFC<Props> = React.memo(({ event }) => {
     <Sectioning id="event_header">
       <Heading level={2} label={event.title} />
       <div className={styles.wrapper}>
-        <p className={styles.detail}>{event.detail}</p>
+        <p className={styles.detail}>
+          <StringWithUrl content={event.detail} />
+        </p>
       </div>
     </Sectioning>
   );


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
イベント概要のテキストに含まれるURLを自動でリンク化し、クリックで遷移できるようにしました。EventHeaderでStringWithUrlを使ってevent.detail内のURLをアンカー表示します。

<!-- End of auto-generated description by cubic. -->

